### PR TITLE
Add task to set the IRVE schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add task to set the schema attribute to the IRVE schema on multiple resources [#3](https://github.com/etalab/udata-schema-gouvfr/pull/3)
 
 ## 1.0.0 (2020-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Add task to set the schema attribute to the IRVE schema on multiple resources [#3](https://github.com/etalab/udata-schema-gouvfr/pull/3)
+- Add a job to set the `schema` attribute to the IRVE schema on multiple resources [#3](https://github.com/etalab/udata-schema-gouvfr/pull/3)
 
 ## 1.0.0 (2020-08-05)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This udata plugin provides an integration with [schema.data.gouv.fr](https://sch
 
 ## Usage
 
-Install the plugin package in your udata environement:
+Install the plugin package in your udata environment:
 
 ```bash
 pip install udata-schema-gouvfr
@@ -27,3 +27,13 @@ PLUGINS = ['schema-gouvfr']
 You can control this plugin behavior with the following `udata.cfg` parameters:
 
 - **`SCHEMA_GOUVFR_VALIDATA_URL`**: the URL to your [Validata](https://validata.fr/) instance (without trailing slash). **ex:** `https://validata.etalab.studio`
+- **`SCHEMA_GOUVFR_IRVE_STABLE_RESOURCE_URL`**: the permalink to the consolidated [IRVE dataset](irve-dataset)'s latest resource. **ex:** `https://www.data.gouv.fr/fr/datasets/r/50625621-18bd-43cb-8fde-6b8c24bdabb3`
+
+## Jobs
+
+This plugin declares jobs.
+
+- **`udata job run set-irve-schemas`**: sets the `schema` attribute of resources that are consolidated as part of [the national IRVE dataset](irve-dataset)
+
+
+[irve-dataset]: https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques/

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,2 @@
 udata>=2.1.4.dev
+requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ testpaths = tests
 python_files = test_*.py
 python_functions = test_*
 python_classes = *Test
+
+[flake8]
+max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ setup(
         'udata.views': [
             'schema-gouvfr = udata_schema_gouvfr.views',
         ],
+        'udata.tasks': [
+            'schema-gouvfr = udata_schema_gouvfr.tasks',
+        ],
     },
     license='MIT',
     zip_safe=False,

--- a/udata_schema_gouvfr/settings.py
+++ b/udata_schema_gouvfr/settings.py
@@ -1,5 +1,11 @@
 '''
 Default settings for udata-schema-gouvfr
 '''
+
 # The Validata instance URL
 SCHEMA_GOUVFR_VALIDATA_URL = 'https://validata.etalab.studio'
+
+# The permalink to the consolidated IRVE dataset's latest resource
+SCHEMA_GOUVFR_IRVE_STABLE_RESOURCE_URL = (
+    "https://www.data.gouv.fr/fr/datasets/r/50625621-18bd-43cb-8fde-6b8c24bdabb3"
+)

--- a/udata_schema_gouvfr/tasks.py
+++ b/udata_schema_gouvfr/tasks.py
@@ -1,5 +1,6 @@
 import re
 import csv
+import uuid
 import codecs
 import logging
 
@@ -56,7 +57,7 @@ def set_irve_schemas(sources):
     log.info(f'Preparing to set the {IRVE_SCHEMA} schema on {len(sources)} resources')
     for source in sources:
         dataset_slug, resource_id = re.match(pattern, source).groups()
-        resource = get_resource(resource_id)
+        resource = get_resource(uuid.UUID(resource_id))
         if not resource:
             raise ValueError(f'Cannot find a resource with ID {resource_id}')
         resource.schema = IRVE_SCHEMA

--- a/udata_schema_gouvfr/tasks.py
+++ b/udata_schema_gouvfr/tasks.py
@@ -1,0 +1,69 @@
+import re
+import csv
+import codecs
+import logging
+
+import requests
+
+from udata.tasks import job
+from udata.core.dataset.models import get_resource, ResourceSchema
+
+log = logging.getLogger(__name__)
+
+
+IRVE_STABLE_DATASET_URL = (
+    "https://www.data.gouv.fr/fr/datasets/r/50625621-18bd-43cb-8fde-6b8c24bdabb3"
+)
+IRVE_SCHEMA = "etalab/schema-irve"
+
+
+def find_sources():
+    """
+    Find all (dataset, resource) listed in the consolidated IRVE resource
+    """
+    response = requests.get(IRVE_STABLE_DATASET_URL)
+    response.raise_for_status()
+
+    sources = set()
+    reader = csv.DictReader(
+        codecs.iterdecode(response.iter_lines(), "utf-8"), delimiter=";"
+    )
+    for record in reader:
+        sources.add(record["source"])
+
+    return sources
+
+
+def ensure_irve_schema_exists():
+    """
+    Ensure that the IRVE schema exists
+    """
+    if not any([el["id"] == IRVE_SCHEMA for el in ResourceSchema.objects()]):
+        raise ValueError(f"{IRVE_SCHEMA} is not a valid schema")
+
+
+def set_irve_schemas(sources):
+    """
+    Update a list of resources by setting the schema attribute to
+    the IRVE schema
+    """
+    ensure_irve_schema_exists()
+
+    pattern = re.compile(
+        r"^https://www\.data\.gouv\.fr/fr/datasets/([\S]+)/#resource-([\S]+)$"
+    )
+
+    log.info(f'Preparing to set the {IRVE_SCHEMA} schema on {len(sources)} resources')
+    for source in sources:
+        dataset_slug, resource_id = re.match(pattern, source).groups()
+        resource = get_resource(resource_id)
+        if not resource:
+            raise ValueError(f'Cannot find a resource with ID {resource_id}')
+        resource.schema = IRVE_SCHEMA
+        resource.save()
+        log.info(f'Set the {IRVE_SCHEMA} on resource {resource_id} from dataset {dataset_slug}')
+
+
+@job("set-irve-schemas")
+def run_set_irve_schemas(self):
+    set_irve_schemas(find_sources())


### PR DESCRIPTION
This job uses the IRVE consolidated dataset to set the schema attribute of multiple resources to the IRVE schema.

It can be run once or be scheduled monthly, after the dataset is updated